### PR TITLE
fix: 핸들 대소문자 처리 수정

### DIFF
--- a/src/app/api/db/create-question/route.ts
+++ b/src/app/api/db/create-question/route.ts
@@ -72,7 +72,7 @@ export async function POST(req: NextRequest) {
         if (!tokenPayload) {
           throw new Error(`No Auth Token`);
         }
-        if (tokenPayload.handle.toLowerCase() !== data.questioner.toLowerCase()) {
+        if (tokenPayload.handle !== data.questioner) {
           throw new Error(`Token and questioner not match`);
         }
       } catch (err) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,18 +52,18 @@ const mastodonAuth = async ({ host }: loginReqDto) => {
 
 /**
  * https://example.com/ 같은 URL 형식으로 온 경우 Host 형식으로 변환
- * host형식으로 온 경우 그대로 반환
+ * 소문자 처리
  * @param urlOrHost
  * @returns
  */
-function urlToHost(urlOrHost: string) {
+function convertHost(urlOrHost: string) {
   const re = /\/\/[^/@\s]+(:[0-9]{1,5})?\/?/;
   const matched_str = urlOrHost.match(re)?.[0];
   if (matched_str) {
     console.log(`URL ${urlOrHost} replaced with ${matched_str.replaceAll('/', '')}`);
-    return matched_str.replaceAll('/', '');
+    return matched_str.replaceAll('/', '').toLowerCase();
   }
-  return urlOrHost;
+  return urlOrHost.toLowerCase();
 }
 
 export default function Home() {
@@ -80,7 +80,7 @@ export default function Home() {
 
   const onSubmit: SubmitHandler<FormValue> = async (e) => {
     setIsLoading(true);
-    const host = urlToHost(e.address);
+    const host = convertHost(e.address);
     localStorage.setItem('server', host);
 
     detectInstance(host).then((type) => {
@@ -89,20 +89,7 @@ export default function Home() {
       };
       switch (type) {
         case 'misskey':
-          localStorage.setItem('server', host);
-          misskeyAuth(payload)
-            .then((r) => {
-              setIsLoading(false);
-              router.replace(r.url);
-            })
-            .catch((err) => {
-              setIsLoading(false);
-              setErrorMessage(err);
-              errModalRef.current?.showModal();
-            });
-          break;
         case 'cherrypick':
-          localStorage.setItem('server', host);
           misskeyAuth(payload)
             .then((r) => {
               setIsLoading(false);
@@ -115,7 +102,6 @@ export default function Home() {
             });
           break;
         case 'mastodon':
-          localStorage.setItem('server', host);
           mastodonAuth(payload)
             .then((r) => {
               router.replace(r);


### PR DESCRIPTION
# 버그 수정

- 기명 질문시 핸들의 대소문자가 틀려도 통과하는 문제 수정
  - 대소문자 잘못된 상태로 통과시 질문자 프로필로 가는 링크가 깨지게 됨
- 로그인시 로컬스토리지에 hostname이 대문자 포함된 상태로 들어갈 수 있는 문제 해결
  - 이걸로 인해서 질문함 공유 버튼이 활성화되지 않을 수 있는 문제도 해결