### PR TITLE
Feat:  JWT 갱신과 취소 가능 기능 

### DIFF
--- a/prisma/migrations/20241124155645_jwt_index/migration.sql
+++ b/prisma/migrations/20241124155645_jwt_index/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "jwtIndex" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model user {
     token           String
     userId          String   @unique
     profile         profile?
+    jwtIndex        Int      @default(0)
 }
 
 model profile {

--- a/src/app/_dto/fetch-name-with-emoji/fetch-name-with-emoji.dto.ts
+++ b/src/app/_dto/fetch-name-with-emoji/fetch-name-with-emoji.dto.ts
@@ -1,6 +1,6 @@
 import { IsArray, IsBoolean, IsOptional, IsString, ValidateIf } from 'class-validator';
 
-class mastodonEmojiModel {
+export class mastodonEmojiModel {
   @IsString()
   shortcode: string;
 

--- a/src/app/_dto/fetch-name-with-emoji/fetch-name-with-emoji.dto.ts
+++ b/src/app/_dto/fetch-name-with-emoji/fetch-name-with-emoji.dto.ts
@@ -22,8 +22,9 @@ export class fetchNameWithEmojiReqDto {
   @IsString()
   baseUrl: string;
 
-  // 마스토돈의 경우 닉네임에 들어간 커모지를
-  // 배열로 따로 주기 때문에 그것에 대한 Validation이 필요함
+  /** 마스토돈의 경우 닉네임에 들어간 커모지를
+  배열로 따로 주기 때문에 그것에 대한 Validation이 필요함
+  */
   @IsArray()
   @IsOptional()
   emojis: mastodonEmojiModel[] | null;

--- a/src/app/_dto/refresh-token/refresh-token.dto.ts
+++ b/src/app/_dto/refresh-token/refresh-token.dto.ts
@@ -1,0 +1,10 @@
+import { IsInt, IsString } from "class-validator";
+
+export class RefreshTokenReqDto {
+  @IsString()
+  /** 사실 꼭 필요하진 않은데 디버깅용... */
+  handle: string;
+
+  @IsInt()
+  last_refreshed_time: number;
+}

--- a/src/app/api/_mastodon-entities/user.ts
+++ b/src/app/api/_mastodon-entities/user.ts
@@ -1,0 +1,24 @@
+import { mastodonEmojiModel } from "@/app/_dto/fetch-name-with-emoji/fetch-name-with-emoji.dto";
+
+/**
+ * Mastodon /api/v1/accounts/verify_credentials 에서 돌아오는 응답중에 필요한 것만 추린것
+ * 아마도.. .문제 없겠지?
+ */
+export type MastodonUser = {
+  id: string;
+  username: string;
+  acct: string;
+  display_name?: string | null;
+  locked: boolean;
+  bot: boolean;
+  created_at: string;
+  url: string;
+  avatar: string | null;
+  avatar_static?: string | null;
+  header: string | null;
+  header_static?: string | null;
+  followers_count?: number;
+  following_count?: number;
+  statuses_count?: number;
+  emojis: mastodonEmojiModel[];
+};

--- a/src/app/api/_utils/jwt/generate-jwt.ts
+++ b/src/app/api/_utils/jwt/generate-jwt.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { SignJWT } from 'jose';
+import { jwtPayload } from './jwtPayload';
+
+export async function generateJwt(hostname: string, handle: string, jwtIndex: number) {
+  const alg = 'HS256';
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+  const jwtPayload: jwtPayload = {
+    server: hostname,
+    handle: handle,
+    jwtIndex: jwtIndex,
+  };
+
+  const webUrl = process.env.WEB_URL;
+  const jwtToken = await new SignJWT(jwtPayload)
+    .setProtectedHeader({ alg })
+    .setIssuedAt()
+    .setIssuer(`${webUrl}`)
+    .setAudience('urn:example:audience')
+    .setExpirationTime('7d')
+    .sign(secret);
+  return jwtToken;
+}

--- a/src/app/api/_utils/jwt/jwtPayload.ts
+++ b/src/app/api/_utils/jwt/jwtPayload.ts
@@ -1,0 +1,5 @@
+export type jwtPayload = {
+  handle: string;
+  server: string;
+  jwtIndex: number;
+};

--- a/src/app/api/web/fetch-name-with-emoji/route.ts
+++ b/src/app/api/web/fetch-name-with-emoji/route.ts
@@ -21,26 +21,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ nameWithEmoji: [] });
   }
   const emojiInUsername = name.match(/:[\w]+:/g)?.map((el) => el.replaceAll(':', ''));
-  const nameArray = name.split(':').filter((el) => el !== '');
+  let nameArray = name.split(':').filter((el) => el !== '');
 
   const instanceType = await detectInstance(baseUrl);
 
   switch (instanceType) {
     case 'mastodon':
       try {
-        if (emojiInUsername && data.emojis) {
-          for (let i = 0; i < emojiInUsername.length; i++) {
-            usernameEmojiAddress.push(data.emojis[i].url);
-          }
-
-          for (const el in nameArray) {
-            usernameIndex.push(nameArray.indexOf(emojiInUsername[el]));
-          }
-          const filteredIndex = usernameIndex.filter((value) => value >= 0);
-
-          for (let i = 0; i < usernameEmojiAddress.length; i++) {
-            nameArray.splice(filteredIndex[i], 1, usernameEmojiAddress[i]);
-          }
+        if (emojiInUsername && data.emojis !== null) {
+          const emojis = data.emojis;
+          const newNameArray = nameArray.map((v) => {
+            const matched_emoji_url = emojis.find((emoji) => emoji.shortcode === v)?.url;
+            if (matched_emoji_url) {
+              return matched_emoji_url;
+            } else {
+              return v;
+            }
+          });
+          nameArray = newNameArray;
         }
         return NextResponse.json({ nameWithEmoji: nameArray });
       } catch (err) {

--- a/src/app/api/web/misskey-login/route.ts
+++ b/src/app/api/web/misskey-login/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
       const payload = {
         name: 'Neo-Quesdon',
         description: '새로운 퀘스돈, 네오-퀘스돈입니다.',
-        permission: ['write:notes'],
+        permission: ['read:account','read:blocks', 'read:following', 'write:notes'],
         callbackUrl: `${process.env.WEB_URL}/misskey-callback`,
       };
 

--- a/src/app/api/web/refresh-token/route.ts
+++ b/src/app/api/web/refresh-token/route.ts
@@ -1,0 +1,236 @@
+import { RefreshTokenReqDto } from '@/app/_dto/refresh-token/refresh-token.dto';
+import { Logger } from '@/utils/logger/Logger';
+import { validateStrict } from '@/utils/validator/strictValidator';
+import { NextRequest, NextResponse } from 'next/server';
+import { sendApiError } from '../../_utils/apiErrorResponse/sendApiError';
+import { verifyToken } from '../../_utils/jwt/verify-jwt';
+import { cookies } from 'next/headers';
+import { GetPrismaClient } from '../../_utils/getPrismaClient/get-prisma-client';
+import { profile, user } from '@prisma/client';
+import { createHash } from 'crypto';
+import { MiUser } from '../../_misskey-entities/user';
+import { fetchNameWithEmoji } from '../../_utils/fetchUsername';
+import { generateJwt } from '../../_utils/jwt/generate-jwt';
+import { MastodonUser } from '../../_mastodon-entities/user';
+
+const logger = new Logger('refresh-token');
+export async function POST(req: NextRequest) {
+  let data;
+  try {
+    data = await validateStrict(RefreshTokenReqDto, await req.json());
+  } catch (err) {
+    return sendApiError(400, `Bad Request! ${err}`);
+  }
+  const cookieStore = await cookies();
+  let tokenPayload;
+  try {
+    tokenPayload = await verifyToken(cookieStore.get('jwtToken')?.value);
+    if (tokenPayload.handle !== data.handle) {
+      throw new Error('Handle not match with JWT');
+    }
+  } catch (err) {
+    return sendApiError(401, `Auth Error! ${err}`);
+  }
+  const prisma = GetPrismaClient.getClient();
+  const user = await prisma.user.findUniqueOrThrow({ where: { handle: tokenPayload.handle } });
+
+  try {
+    await refreshAndReValidateToken(user);
+    const jwtToken = await generateJwt(user.hostName, user.handle, user.jwtIndex);
+    cookieStore.set('jwtToken', jwtToken, {
+      expires: Date.now() + 1000 * 60 * 60 * 24 * 7,
+      httpOnly: true,
+    });
+  } catch (err) {
+    logger.warn('User가 미스키/마스토돈에서 앱 권한을 Revoke한것 같아요. JWT index를 올릴게요. 자세한 정보:', err);
+    await prisma.user.update({where: {handle: user.handle}, data: {jwtIndex: (user.jwtIndex + 1)}});
+    return sendApiError(401, `Refresh user failed!! ${err}`);
+  }
+
+  return NextResponse.json({ message: '야호 JWT 갱신에 성공했어요!' }, { status: 200 });
+}
+
+/**
+ * 유저의 정보를 인스턴스에서 다시 가져와서 프로필을 업데이트함.
+ * 인스턴스에서 권한 문제로 실패한 경우 Throw.
+ * @param user
+ * @returns Promise<void>
+ */
+async function refreshAndReValidateToken(user: user): Promise<void> {
+  const prisma = GetPrismaClient.getClient();
+  const userServer = await prisma.server.findUniqueOrThrow({ where: { instances: user.hostName } });
+
+  /** 테이블에 저장된 user의 Misskey / Mastodon access token */
+  let userToken = user.token;
+  if (userServer.instanceType === 'cherrypick' || userServer.instanceType === 'misskey') {
+    /** Misskey/Cherrypick 인 경우는 저장된 access token을 i로 변환해야 함 */
+    const i = createHash('sha256')
+      .update(userToken + userServer.appSecret, 'utf-8')
+      .digest('hex');
+    userToken = i;
+  }
+
+  switch (userServer.instanceType) {
+    case 'misskey':
+    case 'cherrypick': {
+      logger.debug('try to get user info from misskey...');
+      let miUser: MiUser;
+      try {
+        const miResponse: MiUser | boolean = await fetchMisskeyUserInfo(userToken, user.hostName);
+        if ((miResponse as boolean) === false) {
+          //단순한 fetch 실패
+          return;
+        } else {
+          miUser = miResponse as MiUser;
+        }
+      } catch (err) {
+        logger.log('미스키 AUTHENTICATION_FAILED... TODO: 유저 JWT무효화 처리');
+        //인증 실패의 경우 여기서 throw
+        throw err;
+      }
+
+      try {
+        const newNameWithEmoji = await fetchNameWithEmoji({
+          name: miUser.name ?? miUser.username,
+          baseUrl: user.hostName,
+          emojis: null,
+        });
+        const updateProfile: Partial<profile> = {
+          avatarUrl: miUser.avatarUrl ?? undefined,
+          name: newNameWithEmoji,
+        };
+        const updateUser: Partial<user> = {
+          name: newNameWithEmoji,
+        };
+        await updateDb(user.handle, updateUser, updateProfile);
+      } catch {
+        return;
+      }
+      logger.log(`Misskey User Updated!`);
+      break;
+    }
+    case 'mastodon': {
+      logger.debug('try to get User info from mastodon...');
+      let mastodonUser;
+      try {
+        const ret = await fetchMastodonUserInfo(userToken, user.hostName);
+        if ((ret as boolean) === false) {
+          return;
+        } else {
+          mastodonUser = ret as MastodonUser;
+        }
+      } catch (err) {
+        // 인증 실패의 경우 여기서 throw
+        logger.log('마스토돈 AUTHENTICATION_FAILED... TODO: 유저 JWT무효화 처리');
+        throw err;
+      }
+      try {
+        const nameWithEmoji = await fetchNameWithEmoji({
+          name: mastodonUser.display_name ?? mastodonUser.username,
+          baseUrl: user.hostName,
+          emojis: mastodonUser.emojis,
+        });
+        const profileUpdate: Partial<profile> = {
+          name: nameWithEmoji,
+          avatarUrl: mastodonUser.avatar ?? undefined,
+        };
+        const userUpdate: Partial<user> = {
+          name: nameWithEmoji,
+        };
+        await updateDb(user.handle, userUpdate, profileUpdate);
+      } catch {
+        return;
+      }
+      logger.log(`Mastodon User Updated!`);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+}
+
+/**
+ * Misskey/Cherrypick 에서 유저 정보를 fetch
+ * 미스키의 응답이 200 인 경우는 json을 반환, 401, 403인 경우는 throw
+ * 401, 403 이 아닌 실패는 false 반환
+ * @param i token
+ * @param host Misskey host
+ * @returns misskey API 'i' 에서 반환된 JSON, 또는 false
+ * @throws Misskey에서 토큰 인증에 실패한 경우
+ */
+async function fetchMisskeyUserInfo(i: string, host: string): Promise<boolean | MiUser> {
+  let res;
+  try {
+    res = await fetch(`https://${host}/api/i`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${i}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ i: i }),
+    });
+  } catch {
+    logger.debug('미스키 i API 호출 실패');
+    return false;
+  }
+  // i 토큰 인증이 실패한 경우
+  if (res.status === 403 || res.status === 401) {
+    logger.warn('Misskey returned AUTHENTICATION_FAILED');
+    throw new Error(`Misskey AUTHENTICATION_FAILED ${await res.text()}`);
+  }
+  // 기타 오류
+  else if (!res.ok) {
+    logger.debug('미스키 i API 호출 실패');
+    return false;
+  }
+  // MiUser 를 받은 경우
+  else {
+    return await res.json();
+  }
+}
+
+/**
+ * Mastodon 에서 유저 정보를 fetch 후 반환.
+ * Mastodon 응답이 200인 경우 json 반환, 인증 실패시 throw, 단순 오류시 false 반환
+ * @param i token
+ * @param host Misskey host
+ * @returns  Mastodon 응답이 200인 경우 json 반환, 권한이 아닌 이유로 실패시 false반환
+ * @throws Mastodon 토큰 인증 실패시 throw
+ */
+async function fetchMastodonUserInfo(token: string, host: string): Promise<boolean | MastodonUser> {
+  let res;
+  try {
+    res = await fetch(`https://${host}/api/v1/accounts/verify_credentials`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-type': 'application/json' },
+    });
+  } catch {
+    // 네트워크 등의 이유로 fetch 자체가 실패한 경우
+    logger.debug('마스토톤 API fetch 실패');
+    return false;
+  }
+  // 마스토돈에서 토큰을 거부한 경우
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`Error! ${await res.text()}`);
+  }
+  // 기타 오류
+  else if (!res.ok) {
+    logger.debug('마스토돈 verify_credentials API 호출 실패');
+    return false;
+  } else {
+    // 설마 200에 json이 아닌 응답을 주겠어?
+    return await res.json();
+  }
+}
+
+/**
+ * user, Profile 테이블 업데이트
+ * @param params
+ */
+async function updateDb(targetUserHandle: string, updateUser: Partial<user>, updateProfile: Partial<profile>) {
+  const prisma = GetPrismaClient.getClient();
+  await prisma.$transaction(async (tx) => {
+    await tx.user.update({ where: { handle: targetUserHandle }, data: updateUser });
+    await tx.profile.update({ where: { handle: targetUserHandle }, data: updateProfile });
+  });
+}

--- a/src/app/index.d.ts
+++ b/src/app/index.d.ts
@@ -37,6 +37,7 @@ export interface typedAnswer {
 }
 
 export interface MkNoteAnswers {
+  i: string;
   cw: string;
   text: string;
   visibility: 'public' | 'home' | 'followers';

--- a/src/app/main/questions/action.ts
+++ b/src/app/main/questions/action.ts
@@ -141,6 +141,7 @@ async function mkMisskeyNote(
   }
 
   const newAnswerNote: MkNoteAnswers = {
+    i: i,
     cw: title,
     text: text,
     visibility: visibility,

--- a/src/app/mastodon-callback/page.tsx
+++ b/src/app/mastodon-callback/page.tsx
@@ -49,6 +49,8 @@ export default function CallbackPage() {
 
           const handle = `@${user.profile.username}@${server}`;
           localStorage.setItem('user_handle', handle);
+          const now = `${Math.ceil(Date.now() / 1000)}`;
+          localStorage.setItem('last_token_refresh', now);
 
           router.replace('/main');
         }

--- a/src/app/misskey-callback/page.tsx
+++ b/src/app/misskey-callback/page.tsx
@@ -58,6 +58,8 @@ export default function CallbackPage() {
 
           const handle = `@${user.username}@${server}`;
           localStorage.setItem('user_handle', handle);
+          const now = `${Math.ceil(Date.now() / 1000)}`;
+          localStorage.setItem('last_token_refresh', now);
 
           router.replace('/main');
         }


### PR DESCRIPTION
## JWT를 갱신하는 기능과 취소하는 기능 구현 
https://github.com/serafuku/neo-quesdon/issues/29
* 유저 테이블에 jwtIndex 라는 카운터 생성
* jwt발급시 body에 index도 넣어서 발급
* 유저 테이블에 저장된 미스키/마스토돈 액세스 토근을 사용하여 주기적으로 액세스토큰의 유효성을 검사
  * 유효하면 유저에게 새 jwt 발급
  * 유효하면 겸사겸사 유저 프로필을 업데이트
  * 유저가 마스토돈/미스키에서 네오퀘스돈의 앱 권한을 취소한 것이 감지되면 jwtIndex를 증가시켜서 이미 발급된 jwt를 무효화

## 기타 fix
* 마스토돈 닉네임에 같은 커모지 여러번 쓴 경우 발생하는 문제 수정
* 미스키에 노트 보낼때 베어러인증 헤더와 바디의 i 를 동시에 보내도록 수정
