### PR TITLE
빠른 재로그인 구현, 자잘한 수정, 리팩토링

### DIFF
--- a/src/app/api/_utils/fetchUsername.ts
+++ b/src/app/api/_utils/fetchUsername.ts
@@ -11,7 +11,7 @@ export async function fetchNameWithEmoji(fetchUserNameReq: fetchNameWithEmojiReq
     body: JSON.stringify(fetchUserNameReq),
   });
   if (!res.ok) {
-    logger.error(`fail to get username with emojis `, res.status, res.statusText);
+    logger.error(`fail to get username with emojis `, res.status, await res.text());
     throw new Error('fail to get username with emojis');
   }
   const body: fetchNameWithEmojiResDto = await res.json();

--- a/src/app/api/_utils/jwt/generate-jwt.ts
+++ b/src/app/api/_utils/jwt/generate-jwt.ts
@@ -2,7 +2,9 @@
 
 import { SignJWT } from 'jose';
 import { jwtPayload } from './jwtPayload';
+import { Logger } from '@/utils/logger/Logger';
 
+const logger = new Logger('generateJwt');
 export async function generateJwt(hostname: string, handle: string, jwtIndex: number) {
   const alg = 'HS256';
   const secret = new TextEncoder().encode(process.env.JWT_SECRET);
@@ -20,5 +22,6 @@ export async function generateJwt(hostname: string, handle: string, jwtIndex: nu
     .setAudience('urn:example:audience')
     .setExpirationTime('7d')
     .sign(secret);
+  logger.log(`Make new JWT: ${JSON.stringify(jwtPayload)}`);
   return jwtToken;
 }

--- a/src/app/api/db/create-question/route.ts
+++ b/src/app/api/db/create-question/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: NextRequest) {
       req_limit: 10,
     });
     if (limited) {
-      return sendApiError(429, '요청 제한에 도달했습니다!');
+      return sendApiError(429, '요청 제한에 도달했습니다! 잠시후 다시 시도해 주세요!');
     }
   } else {
     const limiter = RateLimiterService.getLimiter();
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
       req_limit: 10,
     });
     if (limited) {
-      return sendApiError(429, '요청 제한에 도달했습니다!');
+      return sendApiError(429, '요청 제한에 도달했습니다! 잠시후 다시 시도해 주세요!');
     }
   }
 

--- a/src/app/api/web/refresh-token/route.ts
+++ b/src/app/api/web/refresh-token/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest) {
       httpOnly: true,
     });
   } catch (err) {
-    logger.warn('User가 미스키/마스토돈에서 앱 권한을 Revoke한것 같아요. JWT index를 올릴게요. 자세한 정보:', err);
+    logger.warn('User Revoked Access token. JWT를 Revoke합니다... Detail:', err);
     await prisma.user.update({where: {handle: user.handle}, data: {jwtIndex: (user.jwtIndex + 1)}});
     return sendApiError(401, `Refresh user failed!! ${err}`);
   }

--- a/src/app/api/web/refresh-token/route.ts
+++ b/src/app/api/web/refresh-token/route.ts
@@ -47,6 +47,7 @@ export async function POST(req: NextRequest) {
   const user = await prisma.user.findUniqueOrThrow({ where: { handle: tokenPayload.handle } });
 
   try {
+    logger.log('Try refresh JWT...');
     await refreshAndReValidateToken(user);
     const jwtToken = await generateJwt(user.hostName, user.handle, user.jwtIndex);
     cookieStore.set('jwtToken', jwtToken, {

--- a/src/app/index.d.ts
+++ b/src/app/index.d.ts
@@ -56,3 +56,14 @@ export interface postQuestion {
   answeredPerson: user;
   answeredPersonHandle: string;
 }
+
+export interface DBpayload {
+  account: user['account'];
+  accountLower: user['accountLower'];
+  hostName: user['hostName'];
+  handle: user['handle'];
+  name: profile['name'];
+  avatarUrl: profile['avatarUrl'];
+  accessToken: user['token'];
+  userId: user['userId'];
+};

--- a/src/app/main/questions/action.ts
+++ b/src/app/main/questions/action.ts
@@ -5,7 +5,7 @@ import { verifyToken } from '@/app/api/_utils/jwt/verify-jwt';
 import { sendApiError } from '@/app/api/_utils/apiErrorResponse/sendApiError';
 import { GetPrismaClient } from '@/app/api/_utils/getPrismaClient/get-prisma-client';
 import { Logger } from '@/utils/logger/Logger';
-import { question } from '@prisma/client';
+import { question, server, user } from '@prisma/client';
 import { createHash } from 'crypto';
 import { cookies } from 'next/headers';
 
@@ -21,7 +21,7 @@ export async function getQuestion(id: number) {
   return findWithId;
 }
 
-export async function postAnswer(questionId: question['id'] | null, answer: typedAnswer) {
+export async function postAnswer(questionId: question['id'] | null, typedAnswer: typedAnswer) {
   const postLogger = new Logger('postAnswer');
   const prisma = GetPrismaClient.getClient();
   const cookieStore = await cookies();
@@ -33,113 +33,106 @@ export async function postAnswer(questionId: question['id'] | null, answer: type
   } catch (err) {
     return sendApiError(401, 'Unauthorized');
   }
+  if (!questionId) {
+    return sendApiError(400, 'Bad Request');
+  }
+  const q = await prisma.question.findUniqueOrThrow({ where: { id: questionId } });
+  if (q.questioneeHandle !== tokenPayload.handle) {
+    throw new Error(`This question is not for you`);
+  }
+  const answeredUser = await prisma.user.findUniqueOrThrow({
+    where: {
+      handle: tokenPayload.handle,
+    },
+  });
+  const server = await prisma.server.findUniqueOrThrow({
+    where: {
+      instances: answeredUser.hostName,
+    },
+  });
 
-  if (questionId !== null) {
-    // 트랜잭션으로 All or Nothing 처리
-    const [question, postWithAnswer] = await prisma.$transaction(async (tx) => {
-      const q = await tx.question.findUniqueOrThrow({ where: { id: questionId } });
-      if (q.questioneeHandle !== tokenPayload.handle) {
-        throw new Error(`This question is not for you`);
-      }
-      const a = await tx.answer.create({
-        data: {
-          question: q.question,
-          questioner: q.questioner,
-          answer: answer.answer,
-          answeredPersonHandle: tokenPayload.handle,
-          nsfwedAnswer: answer.nsfwedAnswer,
-        },
-      });
-      await tx.question.delete({
-        where: {
-          id: q.id,
-        },
-      });
+  const userSettings = await prisma.profile.findUniqueOrThrow({
+    where: {
+      handle: tokenPayload.handle,
+    },
+  });
+  const createdAnswer = await prisma.answer.create({
+    data: {
+      question: q.question,
+      questioner: q.questioner,
+      answer: typedAnswer.answer,
+      answeredPersonHandle: tokenPayload.handle,
+      nsfwedAnswer: typedAnswer.nsfwedAnswer,
+    },
+  });
+  const answerUrl = `${process.env.WEB_URL}/main/user/${answeredUser.handle}/${createdAnswer.id}`;
 
-      return [q, a];
-    });
-    const answeredUser = await prisma.user.findUniqueOrThrow({
-      where: {
-        handle: tokenPayload.handle,
-      },
-    });
-
-    const server = await prisma.server.findUniqueOrThrow({
-      where: {
-        instances: answeredUser.hostName,
-      },
-    });
-
-    const instanceType = server.instanceType;
-
-    const baseUrl = process.env.WEB_URL;
-    const answerUrl = `${baseUrl}/main/user/${answeredUser.handle}/${postWithAnswer.id}`;
-    postLogger.log('Created new answer:', answerUrl);
-    //답변 올리는 부분
-    const userSettings = await prisma.profile.findUniqueOrThrow({
-      where: {
-        handle: tokenPayload.handle,
-      },
-    });
-    if (!userSettings.stopPostAnswer) {
-      if (answeredUser && server) {
-        const i = createHash('sha256')
-          .update(answeredUser.token + server.appSecret, 'utf-8')
-          .digest('hex');
-        const host = answeredUser.hostName;
-        if (answer.nsfwedAnswer === true && question.questioner === null) {
-          const title = `⚠️ 이 질문은 NSFW한 질문이에요! #neo_quesdon`;
-          const text = `Q: ${question.question}\nA: ${answer.answer}\n#neo_quesdon ${answerUrl}`;
-          if (instanceType === 'misskey' || instanceType === 'cherrypick') {
-            await mkMisskeyNote(i, title, text, host, answer.visibility);
-          } else {
-            await mastodonToot(answeredUser.token, title, text, host, answer.visibility);
-          }
-        } else if (answer.nsfwedAnswer === false && question.questioner !== null) {
-          const title = `Q: ${question.question} #neo_quesdon`;
-          const text = `질문자:${question.questioner}\nA: ${answer.answer}\n#neo_quesdon ${answerUrl}`;
-          if (instanceType === 'misskey' || instanceType === 'cherrypick') {
-            await mkMisskeyNote(i, title, text, host, answer.visibility);
-          } else {
-            await mastodonToot(answeredUser.token, title, text, host, answer.visibility);
-          }
-        } else if (answer.nsfwedAnswer === true && question.questioner !== null) {
-          const title = `⚠️ 이 질문은 NSFW한 질문이에요! #neo_quesdon`;
-          const text = `질문자:${question.questioner}\nQ:${question.question}\nA: ${answer.answer}\n#neo_quesdon ${answerUrl}`;
-          if (instanceType === 'misskey' || instanceType === 'cherrypick') {
-            await mkMisskeyNote(i, title, text, host, answer.visibility);
-          } else {
-            await mastodonToot(answeredUser.token, title, text, host, answer.visibility);
-          }
-        } else {
-          const title = `Q: ${question.question} #neo_quesdon`;
-          const text = `A: ${answer.answer}\n#neo_quesdon ${answerUrl}`;
-          if (instanceType === 'misskey' || instanceType === 'cherrypick') {
-            await mkMisskeyNote(i, title, text, host, answer.visibility);
-          } else {
-            await mastodonToot(answeredUser.token, title, text, host, answer.visibility);
-          }
-        }
+  if (!userSettings.stopPostAnswer) {
+    let title;
+    let text;
+    if (typedAnswer.nsfwedAnswer === true) {
+      title = `⚠️ 이 질문은 NSFW한 질문이에요! #neo_quesdon`;
+      if (q.questioner) {
+        text = `질문자:${q.questioner}\nQ:${q.question}\nA: ${typedAnswer.answer}\n#neo_quesdon ${answerUrl}`;
       } else {
-        postLogger.error('user not found');
+        text = `Q: ${q.question}\nA: ${typedAnswer.answer}\n#neo_quesdon ${answerUrl}`;
+      }
+    } else {
+      title = `Q: ${q.question} #neo_quesdon`;
+      if (q.questioner) {
+        text = `질문자:${q.questioner}\nA: ${typedAnswer.answer}\n#neo_quesdon ${answerUrl}`;
+      } else {
+        text = `A: ${typedAnswer.answer}\n#neo_quesdon ${answerUrl}`;
       }
     }
+    try {
+      switch (server.instanceType) {
+        case 'misskey':
+        case 'cherrypick':
+          await mkMisskeyNote({ user: answeredUser, server: server }, { title: title, text: text, visibility: typedAnswer.visibility });
+          break;
+        case 'mastodon':
+          await mastodonToot({ user: answeredUser }, { title: title, text: text, visibility: typedAnswer.visibility });
+          break;
+        default:
+          break;
+      }
+    } catch {
+      postLogger.warn('답변 작성 실패!');
+      /// 미스키/마스토돈에 글 올리는데 실패했으면 다시 answer 삭제
+      await prisma.answer.delete({ where: { id: createdAnswer.id } });
+      throw new Error('답변 작성 실패!');
+    }
   }
+
+  await prisma.question.delete({
+    where: {
+      id: q.id,
+    },
+  });
+
+  postLogger.log('Created new answer:', answerUrl);
 }
 
 async function mkMisskeyNote(
-  i: string,
-  title: string,
-  text: string,
-  hostname: string,
-  visibility: 'public' | 'home' | 'followers',
+  { user, server }: {
+    user: user,
+    server: server,
+  },
+  { title, text, visibility }: {
+    title: string,
+    text: string,
+    visibility: MkNoteAnswers['visibility'],
+  }
 ) {
   const NoteLogger = new Logger('mkMisskeyNote');
   // 미스키 CW길이제한 처리
   if (title.length > 100) {
     title = title.substring(0, 90) + '.....';
   }
-
+  const i = createHash('sha256')
+    .update(user.token + server.appSecret, 'utf-8')
+    .digest('hex');
   const newAnswerNote: MkNoteAnswers = {
     i: i,
     cw: title,
@@ -147,7 +140,7 @@ async function mkMisskeyNote(
     visibility: visibility,
   };
   try {
-    const res = await fetch(`https://${hostname}/api/notes/create`, {
+    const res = await fetch(`https://${user.hostName}/api/notes/create`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${i}`,
@@ -155,22 +148,32 @@ async function mkMisskeyNote(
       },
       body: JSON.stringify(newAnswerNote),
     });
-    if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      NoteLogger.warn('User Revoked Access token. JWT를 Revoke합니다... Detail:', await res.text());
+      const prisma = GetPrismaClient.getClient();
+      await prisma.user.update({ where: { handle: user.handle }, data: { jwtIndex: (user.jwtIndex + 1) } });
+      throw new Error('Note Create Fail! (Token Revoked)');
+    }
+    else if (!res.ok) {
       throw new Error(`Note Create Fail! ${await res.text()}`);
     } else {
       NoteLogger.log(`Note Created! ${res.statusText}`);
     }
   } catch (err) {
     NoteLogger.warn(err);
+    throw err;
   }
 }
 
 async function mastodonToot(
-  i: string,
-  title: string,
-  text: string,
-  hostname: string,
-  visibility: 'public' | 'home' | 'followers',
+  { user }: {
+    user: user,
+  },
+  { title, text, visibility }: {
+    title: string,
+    text: string,
+    visibility: MkNoteAnswers['visibility'],
+  }
 ) {
   const tootLogger = new Logger('mastodonToot');
   let newVisibility: 'public' | 'unlisted' | 'private';
@@ -194,22 +197,28 @@ async function mastodonToot(
     visibility: newVisibility,
   };
   try {
-    const res = await fetch(`https://${hostname}/api/v1/statuses`, {
+    const res = await fetch(`https://${user.hostName}/api/v1/statuses`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${i}`,
+        Authorization: `Bearer ${user.token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(newAnswerToot),
     });
-
-    if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      tootLogger.warn('User Revoked Access token. JWT를 Revoke합니다.. Detail:', await res.text());
+      const prisma = GetPrismaClient.getClient();
+      await prisma.user.update({ where: { handle: user.handle }, data: { jwtIndex: (user.jwtIndex + 1) } });
+      throw new Error('Toot Create Fail! (Token Revoked)');
+    }
+    else if (!res.ok) {
       throw new Error(`HTTP Error! status:${await res.text()}`);
     } else {
       tootLogger.log(`Toot Created! ${res.statusText}`);
     }
   } catch (err) {
     tootLogger.warn(`Toot Create Fail!`, err);
+    throw err;
   }
 }
 

--- a/src/app/main/user/[handle]/_answers.tsx
+++ b/src/app/main/user/[handle]/_answers.tsx
@@ -49,7 +49,7 @@ export default function UserPage() {
       if (res.ok) {
         return res.json();
       } else {
-        throw new Error(`fetch-user-answers fail! ${res.status}, ${res.statusText}`);
+        throw new Error(`fetch-user-answers fail! ${res.status}, ${await res.text()}`);
       }
     } catch (err) {
       alert(err);

--- a/src/app/mastodon-callback/action.ts
+++ b/src/app/mastodon-callback/action.ts
@@ -71,13 +71,12 @@ export async function login(loginReqestData: mastodonCallbackTokenClaimPayload) 
       const prisma = GetPrismaClient.getClient();
       const user = await prisma.user.findUniqueOrThrow({where: {handle: user_handle}});
       const jwtToken = await generateJwt(loginReq.mastodonHost, user_handle, user.jwtIndex);
-      logger.log(`Send JWT to Frontend... ${jwtToken}`);
       cookieStore.set('jwtToken', jwtToken, {
-        expires: Date.now() + 1000 * 60 * 60 * 6,
+        expires: Date.now() + 1000 * 60 * 60 * 24 * 7,
         httpOnly: true,
       });
       cookieStore.set('server', loginReq.mastodonHost, {
-        expires: Date.now() + 1000 * 60 * 60 * 6,
+        expires: Date.now() + 1000 * 60 * 60 * 24 * 7,
         httpOnly: true,
       });
     } catch (err) {

--- a/src/app/mastodon-callback/action.ts
+++ b/src/app/mastodon-callback/action.ts
@@ -3,11 +3,11 @@
 import { validateStrict } from '@/utils/validator/strictValidator';
 import { mastodonCallbackTokenClaimPayload } from '../_dto/mastodon-callback/callback-token-claim.dto';
 import { fetchNameWithEmoji } from '../api/_utils/fetchUsername';
-import { DBpayload } from '../misskey-callback/page';
 import { cookies } from 'next/headers';
 import { generateJwt } from '../api/_utils/jwt/generate-jwt';
 import { GetPrismaClient } from '@/app/api/_utils/getPrismaClient/get-prisma-client';
 import { Logger } from '@/utils/logger/Logger';
+import { DBpayload } from '..';
 
 const logger = new Logger('Mastodon-callback');
 export async function login(loginReqestData: mastodonCallbackTokenClaimPayload) {

--- a/src/app/mastodon-callback/page.tsx
+++ b/src/app/mastodon-callback/page.tsx
@@ -49,8 +49,8 @@ export default function CallbackPage() {
 
           const handle = `@${user.profile.username}@${server}`;
           localStorage.setItem('user_handle', handle);
-          const now = `${Math.ceil(Date.now() / 1000)}`;
-          localStorage.setItem('last_token_refresh', now);
+          const now = Math.ceil(Date.now() / 1000);
+          localStorage.setItem('last_token_refresh', `${now}`);
 
           router.replace('/main');
         }

--- a/src/app/misskey-callback/actions.ts
+++ b/src/app/misskey-callback/actions.ts
@@ -70,7 +70,6 @@ export async function login(loginReqestData: misskeyCallbackTokenClaimPayload): 
     const prisma = GetPrismaClient.getClient();
     const user = await prisma.user.findUniqueOrThrow({where: {handle: user_handle}});
     const jwtToken = await generateJwt(loginReq.misskeyHost, user_handle, user.jwtIndex);
-    logger.log(`Send JWT to Frontend... ${jwtToken}`);
     cookieStore.set('jwtToken', jwtToken, {
       expires: Date.now() + 1000 * 60 * 60 * 24 * 7,
       httpOnly: true,

--- a/src/app/misskey-callback/actions.ts
+++ b/src/app/misskey-callback/actions.ts
@@ -1,8 +1,7 @@
 'use server';
-
-import { DBpayload } from './page';
+ 
 import { cookies } from 'next/headers';
-import { misskeyAccessKeyApiResponse } from '..';
+import { DBpayload, misskeyAccessKeyApiResponse } from '..';
 import { MiUser } from '../api/_misskey-entities/user';
 import { fetchNameWithEmoji } from '../api/_utils/fetchUsername';
 import { validateStrict } from '@/utils/validator/strictValidator';

--- a/src/app/misskey-callback/actions.ts
+++ b/src/app/misskey-callback/actions.ts
@@ -118,7 +118,7 @@ async function requestMiAccessTokenAndUserInfo(payload: misskeyCallbackTokenClai
       const resBody = await res.json();
       return resBody;
     } else {
-      logger.error(`Fail to get Misskey Access token`, res.status, res.statusText);
+      logger.warn(`Fail to get Misskey Access token. Misskey Response:`, res.status, await res.text());
       return null;
     }
   } else {

--- a/src/app/misskey-callback/page.tsx
+++ b/src/app/misskey-callback/page.tsx
@@ -58,8 +58,8 @@ export default function CallbackPage() {
 
           const handle = `@${user.username}@${server}`;
           localStorage.setItem('user_handle', handle);
-          const now = `${Math.ceil(Date.now() / 1000)}`;
-          localStorage.setItem('last_token_refresh', now);
+          const now = Math.ceil(Date.now() / 1000);
+          localStorage.setItem('last_token_refresh', `${now}`);
 
           router.replace('/main');
         }

--- a/src/app/misskey-callback/page.tsx
+++ b/src/app/misskey-callback/page.tsx
@@ -1,27 +1,21 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { login } from './actions';
 import { MiUser as MiUser } from '../api/_misskey-entities/user';
 import { misskeyCallbackTokenClaimPayload } from '../_dto/misskey-callback/callback-token-claim.dto';
 import { misskeyUserInfoPayload } from '../_dto/misskey-callback/user-info.dto';
-import type { profile, user } from '@prisma/client';
+import DialogModalOneButton from '../_components/modalOneButton';
 
-export type DBpayload = {
-  account: user['account'];
-  accountLower: user['accountLower'];
-  hostName: user['hostName'];
-  handle: user['handle'];
-  name: profile['name'];
-  avatarUrl: profile['avatarUrl'];
-  accessToken: user['token'];
-  userId: user['userId'];
-};
-
+const onErrorModalClick = () => {
+  window.location.replace('/');
+}
 export default function CallbackPage() {
   const [id, setId] = useState<number>(0);
+  const errModalRef = useRef<HTMLDialogElement>(null);
+  const [errMessage, setErrorMessage] = useState<string>();
 
   const router = useRouter();
 
@@ -50,7 +44,6 @@ export default function CallbackPage() {
           try {
             res = await login(payload);
           } catch (err) {
-            console.error(`login failed!`, err);
             throw err;
           }
 
@@ -64,12 +57,9 @@ export default function CallbackPage() {
           router.replace('/main');
         }
       } catch (err) {
+        setErrorMessage(`로그인 중에 문제가 발생했어요... 다시 시도해 보세요`);
+        errModalRef.current?.showModal();
         console.error(err);
-        return (
-          <div className="w-full h-[100vh] flex flex-col gap-2 justify-center items-center text-3xl">
-            <span>로그인 중에 문제가 발생했어요... 다시 시도해 보세요</span>
-          </div>
-        );
       }
     };
 
@@ -77,9 +67,18 @@ export default function CallbackPage() {
   }, [router]);
 
   return (
-    <div className="w-full h-[100vh] flex flex-col gap-2 justify-center items-center text-3xl">
-      <Image src={`/loading/${id}.gif`} width={64} height={64} alt="Login Loading" unoptimized />
-      <span>로그인하고 있어요...</span>
-    </div>
+    <>
+      <div className="w-full h-[100vh] flex flex-col gap-2 justify-center items-center text-3xl">
+        <Image src={`/loading/${id}.gif`} width={64} height={64} alt="Login Loading" unoptimized />
+        <span>로그인하고 있어요...</span>
+      </div>
+      <DialogModalOneButton
+        title={'오류'}
+        body={`${errMessage}`}
+        buttonText={'확인'}
+        ref={errModalRef}
+        onClick={onErrorModalClick}
+      />
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,19 +51,26 @@ const mastodonAuth = async ({ host }: loginReqDto) => {
 };
 
 /**
- * https://example.com/ 같은 URL 형식으로 온 경우 Host 형식으로 변환
- * 소문자 처리
- * @param urlOrHost
+ * https://example.com/ 같은 URL 형식이나 handle 형식으로 입력한 경우 host로 변환.
+ * host를 소문자 처리후 반환
+ * @param urlOrHostOrHandle
  * @returns
  */
-function convertHost(urlOrHost: string) {
-  const re = /\/\/[^/@\s]+(:[0-9]{1,5})?\/?/;
-  const matched_str = urlOrHost.match(re)?.[0];
-  if (matched_str) {
-    console.log(`URL ${urlOrHost} replaced with ${matched_str.replaceAll('/', '')}`);
-    return matched_str.replaceAll('/', '').toLowerCase();
+function convertHost(urlOrHostOrHandle: string) {
+  const url_regex = /\/\/[^/@\s]+(:[0-9]{1,5})?\/?/;
+  const matched_host_from_url = urlOrHostOrHandle.match(url_regex)?.[0];
+  const handle_regex = /(:?@)[^@\s\n\r\t]+$/g;
+  const matched_host_from_handle = urlOrHostOrHandle.match(handle_regex)?.[0];
+  if (matched_host_from_url) {
+    const replaceed = matched_host_from_url.replaceAll('/', '').toLowerCase();
+    console.log(`URL ${urlOrHostOrHandle} replaced with ${replaceed}`);
+    return replaceed;
+  } else if(matched_host_from_handle) {
+    const replaced = matched_host_from_handle.replaceAll('@', '').toLowerCase();
+    console.log(`Handle ${urlOrHostOrHandle} replaced with ${replaced}`);
+    return replaced;
   }
-  return urlOrHost.toLowerCase();
+  return urlOrHostOrHandle.toLowerCase();
 }
 
 export default function Home() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { loginReqDto } from './_dto/web/login/login.dto';
 import GithubRepoLink from './_components/github';
 import DialogModalOneButton from './_components/modalOneButton';
 import { loginCheck } from '@/utils/checkLogin/fastLoginCheck';
+import { logout } from '@/utils/logout/logout';
 
 interface FormValue {
   address: string;
@@ -51,6 +52,12 @@ const mastodonAuth = async ({ host }: loginReqDto) => {
   return await res.json();
 };
 
+const goWithoutLogin = async () => {
+  try {
+    await logout();
+  } catch {}
+  window.location.replace('/main');
+};
 /**
  * https://example.com/ 같은 URL 형식이나 handle 형식으로 입력한 경우 host로 변환.
  * host를 소문자 처리후 반환
@@ -205,11 +212,7 @@ export default function Home() {
                 </div>
               )}
             </button>
-            <button
-              type="button"
-              className={`btn ml-4 ${isLoading ? 'btn-disabled' : 'btn-outline'}`}
-              onClick={() => (window.location.href = '/main')}
-            >
+            <button type="button" className={`btn ml-4 ${isLoading ? 'btn-disabled' : 'btn-outline'}`} onClick={goWithoutLogin}>
               로그인 없이 즐기기
             </button>
           </div>

--- a/src/utils/checkLogin/fastLoginCheck.ts
+++ b/src/utils/checkLogin/fastLoginCheck.ts
@@ -1,0 +1,18 @@
+'use client';
+
+export async function loginCheck(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/db/fetch-my-profile', {
+      method: 'GET',
+    });
+    if (!res.ok) {
+      return false;
+    } else {
+      return true;
+    }
+
+  } catch (err) {
+    console.log('로그인 체크 실패', err);
+    return false;
+  }
+}

--- a/src/utils/logout/logout.ts
+++ b/src/utils/logout/logout.ts
@@ -1,0 +1,9 @@
+'use client';
+
+export async function logout() {
+  try {
+    await fetch('/api/web/logout');
+  } catch {}
+  localStorage.removeItem('user_handle');
+  window.location.reload();
+}

--- a/src/utils/refreshJwt/refresh-jwt-token.ts
+++ b/src/utils/refreshJwt/refresh-jwt-token.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { RefreshTokenReqDto } from '@/app/_dto/refresh-token/refresh-token.dto';
+import { logout } from '../logout/logout';
+
+/**
+ * /api/web/refresh-token 를 호출해서 JWT를 Refresh 하려고 시도합니다. 
+ * 만약 JWT가 인증 해제된 경우 로그아웃을 수행합니다. 
+ * 성공적으로 JWT를 refresh 한 경우 last_token_refresh 를 현재 시간으로 업데이트합니다. 
+ */
+export async function refreshJwt() {
+  const now = Math.ceil(Date.now() / 1000);
+  const user_handle = localStorage.getItem('user_handle');
+  const last_token_refresh = Number.parseInt(localStorage.getItem('last_token_refresh') ?? '0');
+  if (!user_handle) return;
+  try {
+    const req: RefreshTokenReqDto = {
+      handle: user_handle,
+      last_refreshed_time: last_token_refresh,
+    };
+    const res = await fetch('/api/web/refresh-token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(req),
+    });
+    if (res.status === 401 || res.status === 403) {
+      alert(`마스토돈/미스키 에서 앱 인증이 해제되었어요!`);
+      await logout();
+    }
+    localStorage.setItem('last_token_refresh', `${now}`);
+  } catch (err) {
+    console.error(err);
+  }
+}


### PR DESCRIPTION
## 빠른 재 로그인
- https://github.com/serafuku/neo-quesdon/issues/49
- 이미 로그인 된 계정이 있는 경우에 탑 페이지에서 로그인 버튼을 누르면 빠르게 로그인되는 기능 구현

## 자잘한 수정
- 로그인 없이 즐기기 버튼을 누르면 확실하게 '로그인 없이' 가 되도록 로그아웃을 처리 후 리디렉션
- 답변 작성시 툿/노트를 올리던 중에 액세스토큰이 무효화된 것을 발견하면 JWT를 자동으로 무효화 시키도록
- 서버 입력창에 유저 핸들을 입력한 경우라도 알잘딱(tm)하게 처리하도록
- 로그인 콜백 페이지에서 뭔가 실패한 경우 모달창으로 오류 보여주도록


## 리팩토링
- 답변 작성 로직 리팩토링
- refactor: JWT Refresh 와 logout 은 유틸함수로 분리
