### PR TITLE
fix: user테이블의 userId Unique제약 삭제

### DIFF
--- a/prisma/migrations/20241205091719_user_id_is_not_unique/migration.sql
+++ b/prisma/migrations/20241205091719_user_id_is_not_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "user_userId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model user {
   handle       String   @unique
   name         String[]
   token        String
-  userId       String   @unique
+  userId       String   /// Misskey/Mastodon 의 내부 ID
   profile      profile?
   jwtIndex     Int      @default(0)
   server       server   @relation(references: [instances], fields: [hostName], onUpdate: Cascade, onDelete: Cascade)

--- a/src/app/_components/collapseMenu.tsx
+++ b/src/app/_components/collapseMenu.tsx
@@ -1,7 +1,7 @@
 export default function CollapseMenu({ text, id, children }: { text: string; id: string; children: React.ReactNode }) {
   return (
     <div className="w-full">
-      <div className="collapse collapse-arrow backdrop-brightness-105 drop-shadow-md dark:backdrop-brightness-75">
+      <div className="collapse collapse-arrow backdrop-brightness-125 drop-shadow-md dark:backdrop-brightness-75">
         <input type="checkbox" id={id} />
         <div className="collapse-title cursor-pointer font-thin dark:font-normal">{text}</div>
         <div className="collapse-content">{children}</div>

--- a/src/app/mastodon-callback/action.ts
+++ b/src/app/mastodon-callback/action.ts
@@ -156,6 +156,7 @@ async function pushDB(payload: DBpayload) {
     update: {
       name: payload.name,
       token: payload.accessToken,
+      userId: payload.userId,
       profile: {
         update: {
           account: payload.account,

--- a/src/app/misskey-callback/actions.ts
+++ b/src/app/misskey-callback/actions.ts
@@ -137,6 +137,7 @@ async function pushDB(payload: DBpayload) {
     update: {
       name: payload.name,
       token: payload.accessToken,
+      userId: payload.userId,
       profile: {
         update: {
           account: payload.account,


### PR DESCRIPTION
### fix: user테이블의 userId Unique제약 삭제
- userId는 마스토돈/미스키의 내부 유저 ID임
- 다른 인스턴스끼리는 우연히 겹칠 수 있음
- 심지어 인스턴스가 '새로운 시작'을 한 경우 같은 핸들을 가진채로
  userId가 바뀔 수 있음
### UI수정
- 라이트모드에서 설정창 가독성 향상