### PR TITLE
Fix: 화면 작은 모바일 기기 textarea 수정

### DIFF
--- a/src/app/main/settings/page.tsx
+++ b/src/app/main/settings/page.tsx
@@ -260,7 +260,7 @@ export default function Settings() {
                             </div>
                             <textarea
                               {...register('wordMuteList')}
-                              className="textarea textarea-bordered textarea-lg min-h-[15vh] text-sm"
+                              className="textarea textarea-bordered w-full min-h-[15vh] text-base"
                               placeholder="뮤트할 단어, 또는 정규식"
                             ></textarea>
                           </div>


### PR DESCRIPTION
## Fix: 화면 작은 모바일 기기 textarea 수정
- 모바일에서 설정 UI의 textarea 가 삐져나갈 수 있는 문제 해결