### PR TITLE
fix: 미스키 계열 닉네임 이모지 fetch 개선

### DIFF
--- a/src/app/api/web/fetch-name-with-emoji/route.ts
+++ b/src/app/api/web/fetch-name-with-emoji/route.ts
@@ -50,17 +50,13 @@ export async function POST(req: NextRequest) {
       try {
         if (emojiInUsername) {
           for (let i = 0; i < emojiInUsername.length; i++) {
-            const emojiAddress = await fetch(`https://${baseUrl}/api/emoji`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                name: emojiInUsername[i],
-              }),
-            }).then((r) => r.json());
-
-            usernameEmojiAddress.push(emojiAddress.url);
+            try {
+              const emojiAddress = await fetch(`https://${baseUrl}/emojis/${emojiInUsername[i]}`).then((r) => r.json());
+  
+              usernameEmojiAddress.push(emojiAddress.icon.url);
+            } catch {
+              console.error(`emoji ${emojiInUsername[i]} not found in instance ${baseUrl}`);
+            }
           }
 
           for (const el in nameArray) {


### PR DESCRIPTION
미스키 계열 인스턴스는 API를 통하지 않고도 커스텀 이모지 정보를 가져올 수 있어요.

구버전 인스턴스는 API를 통해 커스텀 이모지 정보를 가져올 수 없지만, 이 방법으로는 가져올 수 있어요.

또, 없는 커스텀 이모지를 닉네임에 포함했을 경우 404가 반환되어 fetch에 에러가 발생할 수 있기 때문에, try로 감쌌어요.

이 커밋은 #58 문제를 해결해요.