### PR TITLE
🚑 답변 없을때 로딩스피너 대신 오류텍스트 표시 (수정)

### DIFF
--- a/src/app/main/user/[handle]/[answer]/page.tsx
+++ b/src/app/main/user/[handle]/[answer]/page.tsx
@@ -16,7 +16,9 @@ export default function SingleAnswer() {
     const res = await fetch(`/api/db/answers/${userHandle}/${id}`, {
       method: 'GET',
     });
-    if (!res.ok) {
+    if (res.status === 404) {
+      return null;
+    } else if (!res.ok) {
       throw new Error(`Fail to fetch answer! ${await res.text()}`);
     }
     return await res.json();


### PR DESCRIPTION
## 🚑 답변 없을때 로딩스피너 대신 오류텍스트 표시 (수정)
- 답변 없는데도 로딩스피너만 나오는 버그를 수정