### PR TITLE
:sparkles: 익명 질문자 차단기능

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,16 +99,16 @@ model server {
 
 model blocking {
   id            String   @id @default(cuid())
-  blockeeHandle String   @db.VarChar(500)
+  blockeeTarget String   @db.VarChar(500) @map("blockeeHandle") /// Handle or ipHash
   blockerHandle String   @db.VarChar(500)
   blocker       user     @relation("blocks", fields: [blockerHandle], references: [handle], onDelete: Cascade)
   createdAt     DateTime @default(now())
   hidden        Boolean  @default(false)
   imported      Boolean  @default(false)
 
-  @@unique([blockeeHandle, blockerHandle, hidden, imported])
+  @@unique([blockeeTarget, blockerHandle, hidden, imported])
   @@index([blockerHandle, hidden])
-  @@index([blockeeHandle, hidden])
+  @@index([blockeeTarget, hidden])
   @@index([imported])
 }
 

--- a/src/app/_components/question.tsx
+++ b/src/app/_components/question.tsx
@@ -20,6 +20,7 @@ interface askProps {
   setId: React.Dispatch<React.SetStateAction<number>>;
   deleteRef: RefObject<HTMLDialogElement>;
   answerRef: RefObject<HTMLDialogElement>;
+  blockingRef: RefObject<HTMLDialogElement>;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   defaultVisibility: 'public' | 'home' | 'followers' | undefined;
 }
@@ -31,6 +32,7 @@ export default function Question({
   setId,
   deleteRef,
   answerRef,
+  blockingRef,
   setIsLoading,
   defaultVisibility,
 }: askProps) {
@@ -171,6 +173,15 @@ export default function Question({
             }}
           >
             삭제
+          </span>
+          <span
+            className="text-red-800 font-bold ml-2 cursor-pointer"
+            onClick={() => {
+              setId(singleQuestion.id);
+              blockingRef.current?.showModal();
+            }}
+          >
+            질문자 차단
           </span>
         </div>
       </div>

--- a/src/app/_dto/blocking/blocking.dto.ts
+++ b/src/app/_dto/blocking/blocking.dto.ts
@@ -1,3 +1,4 @@
+import { question } from '@prisma/client';
 import { IsBoolean, IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 export class CreateBlockDto {
@@ -5,7 +6,10 @@ export class CreateBlockDto {
   @MaxLength(500)
   targetHandle: string;
 }
-
+export class createBlockByQuestionDto {
+  @IsInt()
+  questionId: question['id'];
+}
 export class Block {
   id: string;
   targetHandle: string;

--- a/src/app/_dto/blocking/blocking.dto.ts
+++ b/src/app/_dto/blocking/blocking.dto.ts
@@ -1,4 +1,4 @@
-import { question } from '@prisma/client';
+import { blocking, question } from '@prisma/client';
 import { IsBoolean, IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 export class CreateBlockDto {
@@ -56,4 +56,10 @@ export class DeleteBlockDto {
   @IsString()
   @MaxLength(500)
   targetHandle: string;
+}
+
+export class DeleteBlockByIdDto {
+  @IsString()
+  @MaxLength(200)
+  targetId: blocking['id'];
 }

--- a/src/app/api/_service/answer/answer-service.ts
+++ b/src/app/api/_service/answer/answer-service.ts
@@ -388,7 +388,7 @@ export class AnswerService {
       const existList = [];
       for (const block of all_blockList) {
         const exist = await prisma.user.findUnique({
-          where: { handle: block.blockeeHandle },
+          where: { handle: block.blockeeTarget },
         });
         if (exist) {
           existList.push(block);
@@ -397,9 +397,9 @@ export class AnswerService {
       return existList;
     };
     const blockList = await kv.get(getBlockListOnlyExist, { key: `block-${myHandle}`, ttl: 600 });
-    const blockedList = await prisma.blocking.findMany({ where: { blockeeHandle: myHandle, hidden: false } });
+    const blockedList = await prisma.blocking.findMany({ where: { blockeeTarget: myHandle, hidden: false } });
     const filteredAnswers = answers.filter((ans) => {
-      if (blockList.find((b) => b.blockeeHandle === ans.answeredPersonHandle || b.blockeeHandle === ans.questioner)) {
+      if (blockList.find((b) => b.blockeeTarget === ans.answeredPersonHandle || b.blockeeTarget === ans.questioner)) {
         return false;
       }
       if (blockedList.find((b) => b.blockerHandle === ans.answeredPersonHandle || b.blockerHandle === ans.questioner)) {

--- a/src/app/api/_service/question/question-service.ts
+++ b/src/app/api/_service/question/question-service.ts
@@ -83,7 +83,7 @@ export class QuestionService {
       // 블락 여부 검사
       if (tokenPayload?.handle) {
         const blocked = await this.prisma.blocking.findFirst({
-          where: { blockeeHandle: tokenPayload.handle, blockerHandle: questionee_user.handle },
+          where: { blockeeTarget: tokenPayload.handle, blockerHandle: questionee_user.handle },
         });
         if (blocked) {
           return sendApiError(403, '이 사용자에게 질문을 보낼 수 없습니다!');

--- a/src/app/api/_service/question/question-service.ts
+++ b/src/app/api/_service/question/question-service.ts
@@ -81,13 +81,13 @@ export class QuestionService {
         return sendApiError(403, 'User stops NewQuestion');
       }
       // 블락 여부 검사
-      if (tokenPayload?.handle) {
-        const blocked = await this.prisma.blocking.findFirst({
-          where: { blockeeTarget: tokenPayload.handle, blockerHandle: questionee_user.handle },
-        });
-        if (blocked) {
-          return sendApiError(403, '이 사용자에게 질문을 보낼 수 없습니다!');
-        }
+
+      const blockeeTarget = tokenPayload?.handle ?? getIpHash(getIpFromRequest(req));
+      const blocked = await this.prisma.blocking.findFirst({
+        where: { blockeeTarget: blockeeTarget, blockerHandle: questionee_user.handle },
+      });
+      if (blocked) {
+        return sendApiError(403, '이 사용자에게 질문을 보낼 수 없습니다!');
       }
 
       if (!data.isAnonymous && !tokenPayload?.handle) {

--- a/src/app/api/_service/websocket/websocket-service.ts
+++ b/src/app/api/_service/websocket/websocket-service.ts
@@ -275,7 +275,7 @@ export class WebsocketService {
       const existList = [];
       for (const block of all_blockList) {
         const exist = await this.prisma.user.findUnique({
-          where: { handle: block.blockeeHandle },
+          where: { handle: block.blockeeTarget },
         });
         if (exist) {
           existList.push(block);
@@ -287,9 +287,9 @@ export class WebsocketService {
       key: `block-${target_handle}`,
       ttl: 600,
     });
-    const blockedList = await this.prisma.blocking.findMany({ where: { blockeeHandle: target_handle, hidden: false } });
+    const blockedList = await this.prisma.blocking.findMany({ where: { blockeeTarget: target_handle, hidden: false } });
     const filteredClients = client_list.filter((c) => {
-      if (blockList.find((b) => b.blockeeHandle === c.user_handle)) {
+      if (blockList.find((b) => b.blockeeTarget === c.user_handle)) {
         return false;
       }
       if (blockedList.find((b) => b.blockerHandle === c.user_handle)) {

--- a/src/app/api/user/blocking/create-by-question/route.ts
+++ b/src/app/api/user/blocking/create-by-question/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest } from 'next/server';
+import { BlockingService } from '@/app/api/_service/blocking/blocking-service';
+
+export async function POST(req: NextRequest) {
+  const service = BlockingService.get();
+  return await service.createBlockByQuestionApi(req);
+}

--- a/src/app/main/questions/page.tsx
+++ b/src/app/main/questions/page.tsx
@@ -9,6 +9,7 @@ import { MyQuestionEv } from '../_events';
 import { Logger } from '@/utils/logger/Logger';
 import { QuestionDeletedPayload } from '@/app/_dto/websocket-event/websocket-event.dto';
 import { MyProfileContext } from '@/app/main/layout';
+import { createBlockByQuestionDto } from '@/app/_dto/blocking/blocking.dto';
 
 const fetchQuestions = async (): Promise<questionDto[] | null> => {
   const res = await fetch('/api/db/questions');
@@ -36,6 +37,19 @@ async function deleteQuestion(id: number) {
     throw new Error(`질문을 삭제하는데 실패했어요! ${await res.text()}`);
   }
 }
+async function createBlock(id: number) {
+  const body: createBlockByQuestionDto = {
+    questionId: id,
+  };
+  const res = await fetch(`/api/user/blocking/create-by-question`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`차단에 실패했어요! ${await res.text()}`);
+  }
+}
 
 export default function Questions() {
   const [questions, setQuestions] = useState<questionDto[] | null>();
@@ -43,6 +57,7 @@ export default function Questions() {
   const [id, setId] = useState<number>(0);
   const deleteQuestionModalRef = useRef<HTMLDialogElement>(null);
   const answeredQuestionModalRef = useRef<HTMLDialogElement>(null);
+  const createBlockModalRef = useRef<HTMLDialogElement>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const onNewQuestionEvent = (ev: CustomEvent<questionDto>) => {
@@ -92,6 +107,7 @@ export default function Questions() {
                         setQuestions={setQuestions}
                         answerRef={answeredQuestionModalRef}
                         deleteRef={deleteQuestionModalRef}
+                        blockingRef={createBlockModalRef}
                         setIsLoading={setIsLoading}
                         defaultVisibility={profile?.defaultPostVisibility}
                       />
@@ -130,6 +146,16 @@ export default function Questions() {
         onClick={() => {
           deleteQuestion(id);
           setQuestions((prevQuestions) => (prevQuestions ? [...prevQuestions.filter((prev) => prev.id !== id)] : null));
+        }}
+      />
+      <DialogModalTwoButton
+        title={'질문자 차단'}
+        body={'정말 질문자를 차단할까요? 차단된 질문자는 더 이상 나에게 질문을 할 수 없어요!'}
+        confirmButtonText={'확인'}
+        cancelButtonText={'취소'}
+        ref={createBlockModalRef}
+        onClick={() => {
+          createBlock(id);
         }}
       />
     </div>

--- a/src/app/main/settings/_table.tsx
+++ b/src/app/main/settings/_table.tsx
@@ -3,13 +3,13 @@
 import CollapseMenu from '@/app/_components/collapseMenu';
 import DialogModalLoadingOneButton from '@/app/_components/modalLoadingOneButton';
 import DialogModalTwoButton from '@/app/_components/modalTwoButton';
-import { Block, GetBlockListReqDto, GetBlockListResDto } from '@/app/_dto/blocking/blocking.dto';
+import { Block, DeleteBlockByIdDto, GetBlockListReqDto, GetBlockListResDto } from '@/app/_dto/blocking/blocking.dto';
 import { useEffect, useRef, useState } from 'react';
 
 export default function BlockList() {
   const [untilId, setUntilId] = useState<string | null>(null);
   const [blockList, setBlockList] = useState<Block[]>([]);
-  const [unblockHandle, setUnblockHandle] = useState<string | null>(null);
+  const [unblockId, setUnblockId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [mounted, setMounted] = useState<HTMLTableRowElement | null>(null);
   const [loadingDoneModalText, setLoadingDoneModalText] = useState<{ title: string; body: string }>({
@@ -19,12 +19,13 @@ export default function BlockList() {
   const unblockConfirmModalRef = useRef<HTMLDialogElement>(null);
   const unblockSuccessModalRef = useRef<HTMLDialogElement>(null);
 
-  const handleUnBlock = async (handle: string) => {
+  const doUnBlock = async (id: string) => {
     setIsLoading(true);
     unblockSuccessModalRef.current?.showModal();
+    const data: DeleteBlockByIdDto = { targetId: id };
     const res = await fetch('/api/user/blocking/delete', {
       method: 'POST',
-      body: JSON.stringify({ targetHandle: handle }),
+      body: JSON.stringify(data),
     });
     if (!res.ok) {
       setIsLoading(false);
@@ -34,7 +35,7 @@ export default function BlockList() {
       });
       return;
     }
-    setBlockList((prevList) => (prevList ? [...prevList.filter((prev) => prev.targetHandle !== handle)] : []));
+    setBlockList((prevList) => (prevList ? [...prevList.filter((prev) => prev.id !== id)] : []));
     setIsLoading(false);
   };
 
@@ -95,7 +96,7 @@ export default function BlockList() {
                   <button
                     className="btn btn-warning btn-sm w-full break-keep"
                     onClick={() => {
-                      setUnblockHandle(el.targetHandle);
+                      setUnblockId(el.id);
                       unblockConfirmModalRef.current?.showModal();
                     }}
                   >
@@ -134,7 +135,7 @@ export default function BlockList() {
         title={'차단 해제'}
         body={'차단 해제하시겠어요?'}
         confirmButtonText={'확인'}
-        onClick={() => handleUnBlock(unblockHandle!)}
+        onClick={() => doUnBlock(unblockId!)}
         cancelButtonText={'취소'}
         ref={unblockConfirmModalRef}
       />

--- a/src/app/main/user/[handle]/_profile.tsx
+++ b/src/app/main/user/[handle]/_profile.tsx
@@ -213,6 +213,10 @@ export default function Profile() {
         const res = await mkQuestionCreateApi(req);
         if (res.ok) {
           setIsLoading(false);
+          setQuestionSendingDoneMessage({
+            title: '성공',
+            body: '질문했어요!',
+          });
         } else {
           setIsLoading(false);
           setQuestionSendingDoneMessage({ title: '에러', body: `질문을 보내는데 실패했어요! ${await res.text()}` });


### PR DESCRIPTION
## :sparkles: 익명 질문자 차단기능
- 익명 질문자도 차단할 수 있도록 구현
- 익명 질문자를 차단한 경우, 차단된 대상이 누구인지는 알 수는 없도록 블락 목록에서 마스킹 처리를 해서 보여주는 등, 차단된 대상이 누구인지 알아내는 것은 방지. 
  - 왜?: 이렇게 하지 않으면 질문자를 알아내고 싶을때 질문자를 차단한 후 차단 목록을 확인하는 식으로 익명을 우회할 수 있음. 
- 블락 목록에서 차단을 다시 해제 가능하도록
- 비 로그인 질문자였던 경우, ip기반으로 차단

### 예시 사진
#### 이 질문자를 차단
![스크린샷_20241226_155043](https://github.com/user-attachments/assets/7bbe8d07-0401-4f4f-99dc-5553ec4b4d7a)

#### 확인 모달
![스크린샷_20241226_155100](https://github.com/user-attachments/assets/0e0dc4c8-0448-46aa-9b95-79096e5511f9)

#### 익명 질문이었던 경우, 차단목록에 익명화되어서 표시됨
![스크린샷_20241226_155122](https://github.com/user-attachments/assets/a7f5861d-7927-410c-a07e-e48a52e12aad)
